### PR TITLE
make /mars_lightup more reliable

### DIFF
--- a/light_restore_command.lua
+++ b/light_restore_command.lua
@@ -3,7 +3,7 @@ minetest.register_chatcommand("mars_lightup", {
 	description = "restores the airlights on mars around the player position",
 	func = function(name)
 		local player = minetest.get_player_by_name(name)
-		local pos = player:get_pos()
+		local pos = vector.round(player:get_pos())
 
 		if not planet_mars.is_pos_on_mars(pos) then
 			-- TODO: only light up in mars _caves_


### PR DESCRIPTION
Sometimes nothing happens when standing at a certain pos. With rounded pos, standing at the same position it works perfectly.

e.g. standing at  -2450.001953125   15005.5   1672.8519287109 doesn't work.
rounding coordinates results in: -2450   15006    1673 and lightup works fine.

Maybe this is cause for similar unreliable results in other functions that use VoxelManip()/core.get_voxel_manip()