### PR TITLE
tweak /mars_lightup text

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -1,7 +1,7 @@
 local y_start = planet_mars.y_start
 local y_height = planet_mars.y_height
 
--- returns true if the pos is on the mars layer
+-- returns true if the pos is on the Mars layer
 function planet_mars.is_pos_on_mars(pos)
   return pos.y > y_start and pos.y < (y_start + y_height)
 end

--- a/decorations.lua
+++ b/decorations.lua
@@ -1,2 +1,2 @@
 
--- decos for mars caves
+-- decos for Mars caves

--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,5 @@
 planet_mars = {
-	-- starting height of mars terrain
+	-- starting height of Mars terrain
 	y_start = tonumber(minetest.settings:get("planet_mars.y_start")) or 11000,
 
 	-- end height of terrain (relative to start)
@@ -26,4 +26,4 @@ dofile(MP.."/marble.lua")
 dofile(MP.."/light_restore.lua")
 dofile(MP.."/light_restore_command.lua")
 
-print("[OK] Planet: mars (start: " .. planet_mars.y_start .. ", height:" .. planet_mars.y_height .. ")")
+print("[OK] Planet: Mars (start: " .. planet_mars.y_start .. ", height:" .. planet_mars.y_height .. ")")

--- a/light_restore.lua
+++ b/light_restore.lua
@@ -1,7 +1,7 @@
 -- TODO: figure out a way to _properly_ solve this without abm and vmanip hacks!
 
 -- airlight restoration abm
--- slowly reclaims dark spaces on mars
+-- slowly reclaims dark spaces on Mars
 minetest.register_abm({
   label = "mars airlight",
   nodenames = {"air"},
@@ -12,7 +12,7 @@ minetest.register_abm({
 
     -- check coordinates
     if not planet_mars.is_pos_on_mars(pos) then
-      -- we are not on mars, no replacementsare done here
+      -- we are not on Mars, no replacementsare done here
       return
     end
 

--- a/light_restore_command.lua
+++ b/light_restore_command.lua
@@ -1,13 +1,13 @@
 
 minetest.register_chatcommand("mars_lightup", {
-	description = "restores the airlights on mars around the player position",
+	description = "Lights up area around player position on/in Mars",
 	func = function(name)
 		local player = minetest.get_player_by_name(name)
 		local pos = vector.round(player:get_pos())
 
 		if not planet_mars.is_pos_on_mars(pos) then
-			-- TODO: only light up in mars _caves_
-			return false, "You are not on mars!"
+			-- TODO: only light up in Mars _caves_
+			return false, "You are not on or in Mars!"
 		end
 
 		local start = minetest.get_us_time()

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
-Planet mars mod for minetest
+Planet Mars mod for Luanti (Minetest)
 
 
 # Overview
 
-A mars planetary layer with underground caves
+A Mars planetary layer with underground caves
 
 # Mapgen
 

--- a/vacuum.lua
+++ b/vacuum.lua
@@ -10,11 +10,11 @@ if has_vacuum_mod then
 	vacuum.is_pos_in_space = function(pos)
 
 		if pos.y < y_start or pos.y > (y_start + (y_height * 0.95)) then
-			-- not on mars
+			-- not on Mars
 			return old_is_pos_in_space(pos)
 		end
 
-		-- atmosphere in mars caves
+		-- atmosphere in Mars caves
 		return false
 	end
 


### PR DESCRIPTION
There is only one planet called Mars -> proper noun -> capitalized.

Also tweak wording since the command no longer places airlights but adjusts lighting values of all nodes in area.